### PR TITLE
Directory Traversal: Attacker-controlled Data Used in File Path via `self` in `BenefitFormsController.upload`

### DIFF
--- a/app/models/benefits.rb
+++ b/app/models/benefits.rb
@@ -1,14 +1,26 @@
 # frozen_string_literal: true
 class Benefits < ApplicationRecord
 
-  def self.save(file, backup = false)
-    data_path = Rails.root.join("public", "data")
-    full_file_name = "#{data_path}/#{file.original_filename}"
-    f = File.open(full_file_name, "wb+")
-    f.write file.read
-    f.close
-    make_backup(file, data_path, full_file_name) if backup == "true"
+def self.save(file, backup = false)
+  data_path = Rails.root.join("public", "data")
+  # Sanitize the filename to prevent directory traversal
+  safe_filename = File.basename(file.original_filename)
+  full_file_name = File.join(data_path, safe_filename)
+  
+  # Ensure the resulting path is within the intended directory
+  unless full_file_name.start_with?(data_path.to_s)
+    raise SecurityError, "Attempted directory traversal attack"
   end
+  
+  # Create directory if it doesn't exist
+  FileUtils.mkdir_p(data_path) unless File.directory?(data_path)
+  
+  f = File.open(full_file_name, "wb+")
+  f.write file.read
+  f.close
+  make_backup(file, data_path, full_file_name) if backup == "true"
+end
+
 
   def self.make_backup(file, data_path, full_file_name)
     if File.exist?(full_file_name)


### PR DESCRIPTION

# Qwiet AI AutoFix 

This PR was created automatically by the Qwiet AI AutoFix tool.


Some manual intervention might be required before merging this PR.

## Fix for Finding [7](https://app.stg.shiftleft.io/apps/shiftleft-ruby-demo/vulnerabilities?appId=shiftleft-ruby-demo&findingId=7&scan=1)






<details open>
  <summary>Fix Notes</summary>
    <br>
    



The fix addresses directory traversal vulnerability by:

1. Using `File.basename` to extract only the filename portion from user input, removing any path components that could be used for traversal attacks.
2. Using `File.join` for secure path construction instead of string interpolation.
3. Adding a security check to verify that the final path is within the intended directory.
4. Ensuring the target directory exists before writing files.

This implementation follows OWASP's recommendations for preventing path traversal attacks by properly sanitizing user input and implementing appropriate validation before file operations. The fix maintains all original functionality while adding necessary security controls.

</details>



<details>
  <summary>Vulnerability Description</summary>
    <br>
    
Attacker-Controlled input data is used as part of a file path to write a file without escaping or validation. This indicates a directory traversal vulnerability.

- <b> Severity: </b> critical
- <b> CVSS Score: </b> 9 (critical)
- <b> CWE: </b> CWE-22: Directory Traversal

</details>



<details>
  <summary>Attack Payloads</summary>
    <br>
    
```
[
1. ../../../config/initializers/backdoor.rb
2. ../../../../../../etc/passwd
3. ..%2f..%2f..%2fconfig%2fsecret_key_base.yml
]
```

</details>



<details>
  <summary>Testcases</summary>
    <br>
    



```ruby
require 'test_helper'
require 'minitest/autorun'
require 'mocha/minitest'

class DirectoryTraversalTest < ActiveSupport::TestCase
  setup do
    # Mock Rails.root for testing purposes
    Rails.stubs(:root).returns(Pathname.new('/fake/app/path'))
    
    # Create a temporary directory structure for testing
    @data_path = Pathname.new('/fake/app/path/public/data')
    FileUtils.stubs(:mkdir_p).with(@data_path)
    
    # Mock File operations
    @mock_file = mock('file')
    File.stubs(:open).returns(@mock_file)
    @mock_file.stubs(:write)
    @mock_file.stubs(:close)
    
    # Stub the backup method to do nothing during tests
    Benefits.stubs(:make_backup)
  end
  
  test "should detect directory traversal with relative path attack" do
    # Create a mock uploaded file with a malicious filename
    malicious_file = mock('uploaded_file')
    malicious_file.stubs(:original_filename).returns('../../../config/initializers/backdoor.rb')
    malicious_file.stubs(:read).returns('puts "Backdoor installed!"')
    
    # Verify that the file path would be created outside the intended directory
    expected_path = '/fake/app/path/public/data/../../../config/initializers/backdoor.rb'
    File.expects(:open).with(expected_path, 'wb+').raises(SecurityError, "Test prevented file write outside permitted directory")
    
    # Assert that the method raises an error when our safe implementation detects the attack
    assert_raises SecurityError do
      # This would succeed with the vulnerable code, but our test expects the fixed version to raise an error
      Benefits.save(malicious_file)
    end
  end
  
  test "should detect directory traversal targeting system files" do
    # Create a mock uploaded file targeting a system file
    malicious_file = mock('uploaded_file')
    malicious_file.stubs(:original_filename).returns('../../../../../../etc/passwd')
    malicious_file.stubs(:read).returns('malicious content')
    
    # Verify that the attack attempts to write outside the permitted directory
    expected_path = '/fake/app/path/public/data/../../../../../../etc/passwd'
    File.expects(:open).with(expected_path, 'wb+').raises(SecurityError, "Test prevented file write to system file")
    
    # Assert that the method raises an error when our safe implementation detects the attack
    assert_raises SecurityError do
      Benefits.save(malicious_file)
    end
  end
  
  test "should detect URL encoded directory traversal attacks" do
    # Create a mock uploaded file with URL-encoded traversal sequences
    malicious_file = mock('uploaded_file')
    malicious_file.stubs(:original_filename).returns('..%2f..%2f..%2fconfig%2fsecret_key_base.yml')
    malicious_file.stubs(:read).returns('secret_key_base: hacked')
    
    # The decoded path that would be attempted
    expected_path = '/fake/app/path/public/data/..%2f..%2f..%2fconfig%2fsecret_key_base.yml'
    File.expects(:open).with(expected_path, 'wb+').raises(SecurityError, "Test prevented file write with URL-encoded path traversal")
    
    # Assert that the method raises an error when our safe implementation detects the attack
    assert_raises SecurityError do
      Benefits.save(malicious_file)
    end
  end
end
```



</details>



<details>
  <summary>Commits/Files Changed</summary>
  <br>
  <ul>
    
<li> Changed <b> file <a href="https://github.com/soharab-ai/shiftleft-ruby-demo/pull/5/commits/cfdd2913bc2b55e94e5e4c4b6479c1dbee52ddfa"> app/models/benefits.rb </a> </b></li>

  </ul>
</details>
